### PR TITLE
fix: update plugin ID to match package name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import { heychatPlugin } from "./src/channel.js";
 import { setHeychatRuntime } from "./src/runtime.js";
 
 const plugin = {
-  id: "heychat",
+  id: "definersy-heychat-openclaw",
   name: "Heychat",
   description: "Heychat (黑盒语音) channel plugin",
   configSchema: emptyPluginConfigSchema(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "@openclaw/heychat",
-  "version": "2026.2.25",
+  "name": "definersy-heychat-openclaw",
+  "version": "2026.2.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@openclaw/heychat",
-      "version": "2026.2.25",
+      "name": "definersy-heychat-openclaw",
+      "version": "2026.2.28",
+      "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "definersy-heychat-openclaw",
-  "version": "2026.2.28",
+  "version": "2026.2.30",
   "private": false,
   "description": "OpenClaw Heychat (黑盒语音) channel plugin",
   "type": "module",


### PR DESCRIPTION
## Summary
- Change plugin ID from 'heychat' to 'definersy-heychat-openclaw' to match the package name
- Update version to 2026.2.30

## Changes
- `index.ts`: Updated plugin ID
- `package-lock.json`: Updated package name and version
- `package.json`: Updated version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **更新**
  * 插件标识符已更新。
  * 版本号提升至 2026.2.30。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->